### PR TITLE
fix: manejo de resultados cero + swagger actualizado

### DIFF
--- a/controllers/consecutivo.go
+++ b/controllers/consecutivo.go
@@ -134,10 +134,13 @@ func (c *ConsecutivoController) GetAll() {
 		c.Data["mesaage"] = "Error service GetAll: The request contains an incorrect parameter or no record exists"
 		c.Abort("404")
 	} else {
+		var data interface{}
 		if l == nil {
-			l = append(l, map[string]interface{}{})
+			data = []interface{}{}
+		} else {
+			data = l
 		}
-		c.Data["json"] = map[string]interface{}{"Success": true, "Status": "200", "Message": "Request successful", "Data": l}
+		c.Data["json"] = map[string]interface{}{"Success": true, "Status": "200", "Message": "Request successful", "Data": data}
 	}
 	c.ServeJSON()
 }

--- a/controllers/consecutivo.go
+++ b/controllers/consecutivo.go
@@ -83,7 +83,7 @@ func (c *ConsecutivoController) GetOne() {
 // @Param	order	query	string	false	"Order corresponding to each sortby field, if single value, apply to all sortby fields. e.g. desc,asc ..."
 // @Param	limit	query	string	false	"Limit the size of result set. Must be an integer"
 // @Param	offset	query	string	false	"Start position of result set. Must be an integer"
-// @Success 200 {object} models.Consecutivo
+// @Success 200 {object} []models.Consecutivo
 // @Failure 404 not found resource
 // @router / [get]
 func (c *ConsecutivoController) GetAll() {

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -64,7 +64,10 @@
                     "200": {
                         "description": "",
                         "schema": {
-                            "$ref": "#/definitions/models.Consecutivo"
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.Consecutivo"
+                            }
                         }
                     },
                     "404": {

--- a/swagger/swagger.yml
+++ b/swagger/swagger.yml
@@ -46,7 +46,9 @@ paths:
         "200":
           description: ""
           schema:
-            $ref: '#/definitions/models.Consecutivo'
+            type: array
+            items:
+              $ref: '#/definitions/models.Consecutivo'
         "404":
           description: not found resource
     post:


### PR DESCRIPTION
Relacionado con https://github.com/udistrital/contabilidad_cliente/issues/136

## Antes

Para una consulta sin resultados, se retornaba un arreglo de longitud 1, cuyo único elemento es un objeto vacío (`[{}]`)

![image](https://user-images.githubusercontent.com/6588872/149534524-24931ba0-b3bf-4791-b812-642dec24e21e.png)

## Despues

Para la misma consulta, se retorna un arreglo de longitud cero (`[]`)
![image](https://user-images.githubusercontent.com/6588872/149534387-5da1dc55-0c2e-41f5-9c70-5106224785a1.png)

